### PR TITLE
vasyl: grant hermes passwordless sudo

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -533,6 +533,7 @@
     "Servarr",
     "setapp",
     "setsid",
+    "setuid",
     "Shamir",
     "shellcheck",
     "shiftwidth",

--- a/nix/systems/aarch64-linux/vasyl/default.nix
+++ b/nix/systems/aarch64-linux/vasyl/default.nix
@@ -611,6 +611,15 @@ in
           # startup check expects; the module leaves systemd's 90s default,
           # which would SIGKILL the gateway mid-drain.
           TimeoutStopSec = "210s";
+          # The upstream module hardens with NoNewPrivileges = true, which
+          # blocks setuid for the whole process tree — the agent's
+          # passwordless sudo (security.sudo.extraRules below) would be dead
+          # letter under it. ProtectSystem = "strict" must fall with it:
+          # sudo'd children inherit the unit's mount namespace, so system
+          # activation would still see a read-only /etc. mkForce because the
+          # module sets plain values.
+          NoNewPrivileges = lib.mkForce false;
+          ProtectSystem = lib.mkForce false;
         };
       };
 
@@ -719,7 +728,27 @@ in
     '';
   };
 
-  security.sudo.wheelNeedsPassword = false;
+  # The VM is the sandbox: the hermes user gets passwordless sudo (per
+  # Mykhailo) so the agent can self-administer — activate built closures,
+  # restart units, inspect the system — without a host round-trip. The
+  # boundary stays the VM edge, not the uid.
+  security.sudo = {
+    wheelNeedsPassword = false;
+    extraRules = [
+      {
+        users = [ "hermes" ];
+        commands = [
+          {
+            command = "ALL";
+            options = [
+              "NOPASSWD"
+              "SETENV"
+            ];
+          }
+        ];
+      }
+    ];
+  };
 
   # System-level self-management over D-Bus — works under the unit's
   # NoNewPrivileges because PID 1 / polkitd do the privileged work outside the


### PR DESCRIPTION
## Summary
- Add passwordless sudo (`NOPASSWD:SETENV: ALL`) for the `hermes` user on the vasyl VM
- Force off `NoNewPrivileges` and `ProtectSystem` on `hermes-agent.service` — the upstream hermes-agent module hardens with both, which makes sudo a dead letter for the gateway's process tree (`no-new-privileges` blocks setuid; `ProtectSystem=strict` would leave sudo'd children in a read-only mount namespace)
- Add `setuid` to the cspell dictionary

## Rationale
Per Mykhailo: the VM is the sandbox. The agent should activate built closures, restart units, and self-administer without a host round-trip. The boundary stays the VM edge (microvm isolation, firewall, tailnet), not the uid inside it.

## Verification
- `nix flake check` passes (pre-commit incl. cspell, deadnix, statix, treefmt)
- Built toplevel renders `hermes ALL=(ALL:ALL) NOPASSWD:SETENV: ALL` in `/etc/sudoers` and `NoNewPrivileges=false` / `ProtectSystem=false` in the unit
- `nix store diff-closures` against the pre-change build shows only the expected etc/unit delta

Assisted-by: vasyl