### PR TITLE
vasyl: expose spark Ollama in Hermes model picker

### DIFF
--- a/nix/systems/aarch64-linux/vasyl/default.nix
+++ b/nix/systems/aarch64-linux/vasyl/default.nix
@@ -226,6 +226,18 @@ in
             context_length = 131072;
           }
         ];
+        # Give Hermes' /model picker a named row for spark's Ollama endpoint.
+        # The fallback entries above are runtime-only; custom_providers is what
+        # model-switch inventory groups and live-discovers through /v1/models.
+        custom_providers = [
+          {
+            name = "Ollama";
+            base_url = ollamaBaseUrl;
+            api_key = "ollama";
+            api_mode = "chat_completions";
+            discover_models = true;
+          }
+        ];
         auxiliary = {
           compression = {
             provider = "custom";


### PR DESCRIPTION
## Summary
- declares spark's Ollama endpoint as a named Hermes custom provider
- keeps existing fallback provider chain intact
- lets Hermes /model live-discover and select Ollama models from /v1/models

## Verification
- pre-commit hooks on commit: cspell, deadnix, statix, treefmt passed
- nix eval --impure --json .#nixosConfigurations.vasyl.config.services.hermes-agent.settings.custom_providers
- nix-instantiate --parse nix/systems/aarch64-linux/vasyl/default.nix
- nix build --dry-run .#nixosConfigurations.vasyl.config.system.build.toplevel

Assisted-by: vasyl