### PR TITLE
vasyl: add coding agent CLIs

### DIFF
--- a/nix/packages/cursor-agent/default.nix
+++ b/nix/packages/cursor-agent/default.nix
@@ -1,0 +1,50 @@
+{
+  autoPatchelfHook,
+  fetchurl,
+  lib,
+  namespace,
+  stdenv,
+  zlib,
+  ...
+}:
+
+stdenv.mkDerivation rec {
+  pname = "cursor-agent";
+  version = "2026.06.12-01-15-52-7244546";
+
+  src = fetchurl {
+    url = "https://downloads.cursor.com/lab/${version}/linux/arm64/agent-cli-package.tar.gz";
+    hash = "sha256-nLb1s2WLGAkpZpN1dLeQhAk7dkj1To3ShKvU78Rf0ik=";
+  };
+
+  nativeBuildInputs = [ autoPatchelfHook ];
+
+  buildInputs = [
+    stdenv.cc.cc.lib
+    zlib
+  ];
+
+  sourceRoot = "dist-package";
+
+  # cspell:words libexec
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p "$out/libexec/cursor-agent" "$out/bin"
+    cp -R . "$out/libexec/cursor-agent/"
+
+    ln -s "$out/libexec/cursor-agent/cursor-agent" "$out/bin/cursor-agent"
+    ln -s "$out/libexec/cursor-agent/cursor-agent" "$out/bin/agent"
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Cursor Agent CLI";
+    homepage = "https://cursor.com/cli";
+    license = licenses.unfree;
+    maintainers = with lib.${namespace}.maintainers; [ mykhailo ];
+    mainProgram = "cursor-agent";
+    platforms = [ "aarch64-linux" ];
+  };
+}

--- a/nix/systems/aarch64-linux/vasyl/environment.nix
+++ b/nix/systems/aarch64-linux/vasyl/environment.nix
@@ -70,6 +70,19 @@ let
     shfmt
     uv
 
+    # Coding agents. These must be on both the system PATH and Hermes service
+    # PATH so Vasyl can delegate from Matrix/API sessions without per-user npm
+    # installs or mutable ~/.local shims. Cursor ships two CLIs: `cursor` from
+    # the editor package and `cursor-agent`/`agent` from Cursor's agent bundle.
+    pkgs.aider-chat
+    pkgs.claude-code
+    pkgs.code-cursor
+    codex
+    pkgs.land.cursor-agent
+    pkgs.gemini-cli
+    opencode
+    pkgs.qwen-code
+
     # Code search, diffs, and watch/bench/task runners. ast-grep (structural
     # search/rewrite) is agent-critical, so it is repeated here for the service
     # user like ripgrep/fd despite living in the shared shell module. entr


### PR DESCRIPTION
## Summary
- adds OpenCode, Codex, Claude Code, Cursor, Cursor Agent, Aider, Gemini CLI, and Qwen Code to Vasyl's workstation/Hermes service PATH
- packages Cursor Agent from its pinned Linux arm64 bundle as a local unfree package
- keeps agent CLIs declarative instead of relying on npm globals or mutable ~/.local shims

## Verification
- pre-commit hooks on commit: cspell, deadnix, statix, treefmt passed
- nix eval --impure --json .#nixosConfigurations.vasyl.config.environment.systemPackages
- nix build --dry-run .#nixosConfigurations.vasyl.config.system.build.toplevel
- nix build --no-link --print-out-paths .#cursor-agent
- cursor-agent --version from the built package

Assisted-by: vasyl