### PR TITLE
vasyl: fix Parakeet voice transcription

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -223,6 +223,7 @@
     "homerow",
     "hostnames",
     "httpie",
+    "httpx",
     "huihui",
     "hwatch",
     "hwloc",

--- a/nix/systems/aarch64-linux/spark/default.nix
+++ b/nix/systems/aarch64-linux/spark/default.nix
@@ -42,6 +42,13 @@ let
     # it spacy.cli.download()s at startup → crash-loop offline.
     ps.spacy-models.en_core_web_sm
   ]);
+
+  parakeetShimPython = pkgs.python3.withPackages (ps: [
+    ps.fastapi
+    ps.httpx
+    ps.python-multipart
+    ps.uvicorn
+  ]);
 in
 {
   networking = {
@@ -115,46 +122,79 @@ in
       AllowHybridSleep = "no";
     };
 
-    # The nix-daemon authenticates to muscle via the YubiKey, exposed through
-    # mykhailo's gpg-agent ssh socket (same as the Darwin hosts' launchd setup).
-    # uid 1000 = first normal user (uids are auto-allocated, so not in eval).
-    services.nix-daemon.environment.SSH_AUTH_SOCK = "/run/user/1000/gnupg/S.gpg-agent.ssh";
+    services = {
+      # The nix-daemon authenticates to muscle via the YubiKey, exposed through
+      # mykhailo's gpg-agent ssh socket (same as the Darwin hosts' launchd setup).
+      # uid 1000 = first normal user (uids are auto-allocated, so not in eval).
+      nix-daemon.environment.SSH_AUTH_SOCK = "/run/user/1000/gnupg/S.gpg-agent.ssh";
 
-    # TTS for vasyl: Kokoro-82M on CUDA, pure Nix — torch from this host's
-    # cudaSupport package set plus the pinned weights above, no container.
-    # (The stock ghcr.io/remsky/kokoro-fastapi-gpu arm64 image is broken on
-    # sm_121; if this from-source path ever becomes untenable, a self-built
-    # CUDA container would be the fallback.) The ~60-line shim serves
-    # OpenAI-compatible /v1/audio/speech.
-    services.kokoro-openai = {
-      description = "Kokoro-82M TTS (OpenAI-compatible) for vasyl";
-      wantedBy = [ "multi-user.target" ];
-      # Binds the tap edge; if 10.77.0.1 isn't up yet the bind fails and the
-      # restart loop converges once networkd has the address.
-      after = [ "network-online.target" ];
-      wants = [ "network-online.target" ];
-      path = [ pkgs.ffmpeg ];
-      environment = {
-        # Weights are pinned in the store — never touch the hub.
-        HF_HUB_OFFLINE = "1";
-        KOKORO_CONFIG = "${kokoroConfig}";
-        KOKORO_MODEL = "${kokoroModel}";
-        KOKORO_VOICES = "am_michael=${kokoroVoiceMichael}";
-        KOKORO_HOST = "10.77.0.1";
-        KOKORO_PORT = "8101";
-        # Writable HOME for the CUDA/torch JIT caches under DynamicUser.
-        HOME = "/var/cache/kokoro-openai";
+      # TTS for vasyl: Kokoro-82M on CUDA, pure Nix — torch from this host's
+      # cudaSupport package set plus the pinned weights above, no container.
+      # (The stock ghcr.io/remsky/kokoro-fastapi-gpu arm64 image is broken on
+      # sm_121; if this from-source path ever becomes untenable, a self-built
+      # CUDA container would be the fallback.) The ~60-line shim serves
+      # OpenAI-compatible /v1/audio/speech.
+      kokoro-openai = {
+        description = "Kokoro-82M TTS (OpenAI-compatible) for vasyl";
+        wantedBy = [ "multi-user.target" ];
+        # Binds the tap edge; if 10.77.0.1 isn't up yet the bind fails and the
+        # restart loop converges once networkd has the address.
+        after = [ "network-online.target" ];
+        wants = [ "network-online.target" ];
+        path = [ pkgs.ffmpeg ];
+        environment = {
+          # Weights are pinned in the store — never touch the hub.
+          HF_HUB_OFFLINE = "1";
+          KOKORO_CONFIG = "${kokoroConfig}";
+          KOKORO_MODEL = "${kokoroModel}";
+          KOKORO_VOICES = "am_michael=${kokoroVoiceMichael}";
+          KOKORO_HOST = "10.77.0.1";
+          KOKORO_PORT = "8101";
+          # Writable HOME for the CUDA/torch JIT caches under DynamicUser.
+          HOME = "/var/cache/kokoro-openai";
+        };
+        serviceConfig = {
+          ExecStart = "${kokoroPython}/bin/python ${./kokoro-shim.py}";
+          DynamicUser = true;
+          SupplementaryGroups = [
+            "render"
+            "video"
+          ];
+          CacheDirectory = "kokoro-openai";
+          Restart = "on-failure";
+          RestartSec = 5;
+        };
       };
-      serviceConfig = {
-        ExecStart = "${kokoroPython}/bin/python ${./kokoro-shim.py}";
-        DynamicUser = true;
-        SupplementaryGroups = [
-          "render"
-          "video"
+
+      # STT for vasyl: an OpenAI-compatible facade in front of NVIDIA's
+      # Parakeet NIM. The raw NIM endpoint selects the DGX Spark profile by
+      # BCP-47 language and rejects arbitrary OpenAI `model` names; the shim
+      # accepts the normal OpenAI multipart shape from Hermes, ignores `model`,
+      # supplies `language=en-US`, and returns `{ "text": ... }`.
+      parakeet-openai = {
+        description = "Parakeet NIM STT (OpenAI-compatible) for vasyl";
+        wantedBy = [ "multi-user.target" ];
+        wants = [
+          "network-online.target"
+          "docker-parakeet-nim.service"
         ];
-        CacheDirectory = "kokoro-openai";
-        Restart = "on-failure";
-        RestartSec = 5;
+        after = [
+          "network-online.target"
+          "docker-parakeet-nim.service"
+        ];
+        environment = {
+          PARAKEET_HOST = "10.77.0.1";
+          PARAKEET_PORT = "8102";
+          PARAKEET_LANGUAGE = "en-US";
+          PARAKEET_UPSTREAM_URL = "http://127.0.0.1:9000/v1/audio/transcriptions";
+          PARAKEET_TIMEOUT_SECONDS = "300";
+        };
+        serviceConfig = {
+          ExecStart = "${parakeetShimPython}/bin/python ${./parakeet-openai-shim.py}";
+          DynamicUser = true;
+          Restart = "on-failure";
+          RestartSec = 5;
+        };
       };
     };
 
@@ -201,8 +241,9 @@ in
     # STT for vasyl: Parakeet 1.1B RNNT Multilingual as an NVIDIA NIM — the
     # one justified container here (NVIDIA ships it CUDA-ready for Blackwell
     # and the DGX Spark per the speech NIM support matrix; it is the only
-    # Spark-supported Parakeet) serving OpenAI-compatible
-    # /v1/audio/transcriptions on the tap edge. GPU access is CDI:
+    # Spark-supported Parakeet). The raw NIM HTTP API is kept loopback-only;
+    # vasyl reaches it through the OpenAI-compatible parakeet-openai shim on
+    # the tap edge. GPU access is CDI:
     # hardware.nvidia-container-toolkit (dgx-spark module) generates the spec
     # and docker >= 28.2 has CDI on by default, so `--device=nvidia.com/gpu`
     # is the official path (no --runtime=nvidia wrapper on NixOS).
@@ -230,7 +271,7 @@ in
           # it ships no diarizer-disabled profiles, only sortformer+silero.
           NIM_TAGS_SELECTOR = "diarizer=sortformer,mode=ofl,type=default,vad=silero";
         };
-        ports = [ "10.77.0.1:9000:9000" ];
+        ports = [ "127.0.0.1:9000:9000" ];
         volumes = [ "/var/lib/nim/cache:/opt/nim/.cache" ];
         extraOptions = [
           "--device=nvidia.com/gpu=all"

--- a/nix/systems/aarch64-linux/spark/parakeet-openai-shim.py
+++ b/nix/systems/aarch64-linux/spark/parakeet-openai-shim.py
@@ -1,0 +1,95 @@
+"""OpenAI-compatible /v1/audio/transcriptions for Parakeet NIM.
+
+The NVIDIA Parakeet NIM HTTP API exposes a transcription endpoint, but the
+served DGX Spark profile does not accept arbitrary OpenAI-style model names; it
+selects the model by language/profile. This shim keeps clients on the normal
+OpenAI audio API shape while forwarding the request Parakeet actually accepts.
+"""
+
+import os
+from typing import Annotated
+
+import httpx
+import uvicorn
+from fastapi import FastAPI, File, Form, HTTPException, Response, UploadFile
+
+DEFAULT_LANGUAGE = os.environ.get("PARAKEET_LANGUAGE", "en-US")
+UPSTREAM_URL = os.environ["PARAKEET_UPSTREAM_URL"].rstrip("/")
+TIMEOUT_SECONDS = float(os.environ.get("PARAKEET_TIMEOUT_SECONDS", "300"))
+
+app = FastAPI(title="Parakeet OpenAI-compatible transcription shim")
+
+
+def _as_text(payload: object) -> str:
+    if isinstance(payload, dict):
+        text = payload.get("text", "")
+        return text if isinstance(text, str) else str(text)
+    return str(payload)
+
+
+@app.get("/v1/health/ready")
+async def health_ready() -> dict[str, str]:
+    return {"status": "ready"}
+
+
+@app.post("/v1/audio/transcriptions", response_model=None)
+async def transcriptions(
+    file: Annotated[UploadFile, File(description="Audio file to transcribe")],
+    model: Annotated[
+        str | None, Form()
+    ] = None,  # OpenAI clients require it; NIM ignores it.
+    language: Annotated[str | None, Form()] = None,
+    prompt: Annotated[str | None, Form()] = None,
+    response_format: Annotated[str | None, Form()] = "json",
+    temperature: Annotated[float | None, Form()] = None,
+) -> Response | dict[str, str]:
+    del model  # Compatibility field only; raw Parakeet NIM rejects arbitrary model ids.
+
+    audio = await file.read()
+    data: dict[str, str] = {
+        "language": language or DEFAULT_LANGUAGE,
+        "response_format": "json",
+    }
+    if prompt:
+        data["prompt"] = prompt
+    if temperature is not None:
+        data["temperature"] = str(temperature)
+
+    files = {
+        "file": (
+            file.filename or "audio",
+            audio,
+            file.content_type or "application/octet-stream",
+        )
+    }
+    try:
+        async with httpx.AsyncClient(timeout=TIMEOUT_SECONDS) as client:
+            upstream = await client.post(UPSTREAM_URL, data=data, files=files)
+    except httpx.HTTPError as exc:
+        raise HTTPException(502, f"Parakeet upstream request failed: {exc}") from exc
+
+    if upstream.status_code >= 400:
+        raise HTTPException(upstream.status_code, upstream.text)
+
+    try:
+        payload = upstream.json()
+    except ValueError as exc:
+        raise HTTPException(
+            502, "Parakeet upstream returned non-JSON response"
+        ) from exc
+
+    text = _as_text(payload).strip()
+    fmt = (response_format or "json").lower()
+    if fmt == "text":
+        return Response(text, media_type="text/plain")
+    if fmt in {"json", "verbose_json"}:
+        return {"text": text}
+    raise HTTPException(400, f"unsupported response_format: {response_format}")
+
+
+if __name__ == "__main__":
+    uvicorn.run(
+        app,
+        host=os.environ.get("PARAKEET_HOST", "127.0.0.1"),
+        port=int(os.environ.get("PARAKEET_PORT", "8102")),
+    )

--- a/nix/systems/aarch64-linux/vasyl/default.nix
+++ b/nix/systems/aarch64-linux/vasyl/default.nix
@@ -340,10 +340,12 @@ in
         stt = {
           provider = "openai";
           openai = {
-            # Any non-empty value; the NIM endpoint is unauthenticated.
+            # Any non-empty value; the Parakeet shim is unauthenticated.
             api_key = "local";
-            base_url = "http://${hostAddress}:9000/v1";
-            # Any non-"whisper-1" model name makes Hermes request plain JSON.
+            base_url = "http://${hostAddress}:8102/v1";
+            # The shim accepts the normal OpenAI multipart shape and ignores
+            # the model because raw Parakeet NIM selects its profile by
+            # language internally.
             model = "parakeet";
           };
         };


### PR DESCRIPTION
## Summary
- replace the unsafe Hermes shell-command STT workaround with a small spark-side OpenAI-compatible Parakeet shim
- keep Hermes on its built-in `openai` STT provider pointed at `http://10.77.0.1:8102/v1`
- have the shim accept normal OpenAI multipart transcription requests, drop the arbitrary OpenAI `model`, add Parakeet NIM's required `language=en-US`, and normalize responses to `{ "text": ... }`
- bind the raw Parakeet NIM container to `127.0.0.1:9000` and expose only the typed shim on the tap edge
- keep Kokoro TTS unchanged at `http://10.77.0.1:8101/`

## Verification
- `python3 -m py_compile nix/systems/aarch64-linux/spark/parakeet-openai-shim.py`
- `nix fmt`
- `git diff --check`
- pre-commit hooks during amend:
  - `cspell`
  - `deadnix`
  - `editorconfig-checker`
  - `statix`
  - `treefmt`
- `nix eval --impure --json .#nixosConfigurations.vasyl.config.services.hermes-agent.settings.stt`
- `nix eval --impure --json .#nixosConfigurations.spark.config.systemd.services.parakeet-openai.description`
- `nix eval --impure --json .#nixosConfigurations.spark.config.virtualisation.oci-containers.containers.parakeet-nim.ports`
- `nix build --dry-run .#nixosConfigurations.vasyl.config.system.build.toplevel`
- `nix build --dry-run .#nixosConfigurations.spark.config.system.build.toplevel`
- live raw shim STT test returned 200 with transcript JSON from a generated OGG sample
- live Hermes `transcribe_audio` routed through the shim and returned the expected transcript
- live TTS generated `/var/lib/hermes/workspace/voice-test-oai-shim-tts.mp3` via the configured Kokoro provider

Assisted-by: vasyl
