### PR TITLE
home: add Cinny desktop to comms

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -91,6 +91,7 @@
     "chflags",
     "chrony",
     "chronyd",
+    "cinny",
     "CKNN",
     "cmdline",
     "creds",

--- a/nix/modules/home/comms/default.nix
+++ b/nix/modules/home/comms/default.nix
@@ -19,7 +19,8 @@ in
       [
         irssi # IRC
         tg # Telegram
-        iamb # Matrix
+        iamb # Matrix TUI
+        cinny-desktop # Matrix GUI
       ]
       # discord/slack have no aarch64-linux builds; gate them to x86_64-linux and Darwin.
       ++


### PR DESCRIPTION
## Summary
- add `cinny-desktop` to the shared Home Manager comms package set
- keep `iamb` as the Matrix TUI and label Cinny as the Matrix GUI
- add `cinny` to the cspell allowlist

## Verification
- `nix fmt`
- `git diff --check`
- commit-time pre-commit hooks:
  - `cspell`
  - `deadnix`
  - `editorconfig-checker`
  - `statix`
  - `treefmt`
- evaluated `cinny-desktop 4.12.1` exists in nixpkgs for:
  - `x86_64-linux`
  - `aarch64-linux`
  - `aarch64-darwin`
- verified `cinny-desktop` appears in enabled comms home packages for:
  - `mykhailo@potato`
  - `mykhailo@beefy`
  - `mykhailo@muscle`
  - `mykhailo@ghost`
  - `mykhailo@spark`
- `nix build --dry-run` for Linux desktop home activation packages:
  - `mykhailo@muscle`
  - `mykhailo@ghost`
  - `mykhailo@spark`

Assisted-by: vasyl
