### PR TITLE
spark: expose Kokoro TTS and Parakeet STT on the LAN

### DIFF
--- a/nix/systems/aarch64-linux/spark/default.nix
+++ b/nix/systems/aarch64-linux/spark/default.nix
@@ -9,7 +9,8 @@ let
   muscle = lib.${namespace}.shared.builders.muscle;
 
   # Voice stack for vasyl (see ../vasyl): both ends serve OpenAI-compatible
-  # one-shot endpoints on the VM tap edge, next to Ollama.
+  # one-shot endpoints — bound to all interfaces (LAN + Tailnet + the VM tap
+  # edge), next to Ollama.
   #
   # Kokoro-82M weights, declaratively pinned (Apache-2.0). URLs reference an
   # explicit HF revision rather than `main`, so upstream history moving can
@@ -137,8 +138,10 @@ in
       kokoro-openai = {
         description = "Kokoro-82M TTS (OpenAI-compatible) for vasyl";
         wantedBy = [ "multi-user.target" ];
-        # Binds the tap edge; if 10.77.0.1 isn't up yet the bind fails and the
-        # restart loop converges once networkd has the address.
+        # Binds 0.0.0.0 so TTS is reachable on the LAN (enP7s7, e.g.
+        # 192.168.0.172:8101) and the Tailnet, not just the vasyl tap edge
+        # (10.77.0.1) — same all-interfaces exposure as Ollama (below), fine
+        # because the host firewall is off.
         after = [ "network-online.target" ];
         wants = [ "network-online.target" ];
         path = [ pkgs.ffmpeg ];
@@ -148,7 +151,7 @@ in
           KOKORO_CONFIG = "${kokoroConfig}";
           KOKORO_MODEL = "${kokoroModel}";
           KOKORO_VOICES = "am_michael=${kokoroVoiceMichael}";
-          KOKORO_HOST = "10.77.0.1";
+          KOKORO_HOST = "0.0.0.0";
           KOKORO_PORT = "8101";
           # Writable HOME for the CUDA/torch JIT caches under DynamicUser.
           HOME = "/var/cache/kokoro-openai";
@@ -183,7 +186,10 @@ in
           "docker-parakeet-nim.service"
         ];
         environment = {
-          PARAKEET_HOST = "10.77.0.1";
+          # 0.0.0.0: STT shim reachable on the LAN (e.g. 192.168.0.172:8102)
+          # and the Tailnet too, not just the vasyl tap edge. The raw NIM stays
+          # loopback-only (127.0.0.1:9000) — this shim is its only exposed face.
+          PARAKEET_HOST = "0.0.0.0";
           PARAKEET_PORT = "8102";
           PARAKEET_LANGUAGE = "en-US";
           PARAKEET_UPSTREAM_URL = "http://127.0.0.1:9000/v1/audio/transcriptions";

--- a/nix/systems/aarch64-linux/spark/kokoro-shim.py
+++ b/nix/systems/aarch64-linux/spark/kokoro-shim.py
@@ -6,6 +6,7 @@ exactly what Hermes' voice tools and realtime voice-mode clients issue.
 """
 
 import os
+import re
 import subprocess
 import threading
 
@@ -31,6 +32,44 @@ ENCODERS = {
 # "name=/path/to/voice.pt,..." — first entry is the default voice.
 VOICES = dict(pair.split("=", 1) for pair in os.environ["KOKORO_VOICES"].split(","))
 DEFAULT_VOICE = next(iter(VOICES))
+
+# Kokoro renders best on bounded inputs: a single long forward approaches the
+# model's 510-token cap (where KPipeline silently truncates the tail) and is
+# more prone to prosody drift. Split long text into sentence-grouped chunks
+# rendered separately and concatenated. Each chunk's audio begins and ends in
+# silence, so naive concatenation joins cleanly (no clicks). Short inputs — the
+# common case — pass through unchanged as a single chunk.
+MAX_CHARS = 400
+
+
+def chunk_text(text: str) -> list[str]:
+    text = text.strip()
+    if len(text) <= MAX_CHARS:
+        return [text] if text else []
+    chunks: list[str] = []
+    current = ""
+    for sentence in re.split(r"(?<=[.!?])\s+", text):
+        if not sentence:
+            continue
+        if not current:
+            current = sentence
+        elif len(current) + 1 + len(sentence) <= MAX_CHARS:
+            current = f"{current} {sentence}"
+        else:
+            chunks.append(current)
+            current = sentence
+        # A single sentence longer than the cap: hard-split on word boundaries
+        # so no forward exceeds it (only hit by pathological run-on input).
+        while len(current) > MAX_CHARS:
+            cut = current.rfind(" ", 0, MAX_CHARS)
+            if cut <= 0:
+                cut = MAX_CHARS
+            chunks.append(current[:cut].strip())
+            current = current[cut:].strip()
+    if current:
+        chunks.append(current)
+    return chunks
+
 
 model = (
     KModel(
@@ -65,7 +104,8 @@ def speech(request: SpeechRequest) -> Response:
     with lock:
         chunks = [
             result.audio
-            for result in pipeline(request.input, voice=voice, speed=request.speed)
+            for segment in chunk_text(request.input)
+            for result in pipeline(segment, voice=voice, speed=request.speed)
             if result.audio is not None
         ]
     if not chunks:

--- a/nix/systems/aarch64-linux/spark/parakeet-openai-shim.py
+++ b/nix/systems/aarch64-linux/spark/parakeet-openai-shim.py
@@ -4,14 +4,27 @@ The NVIDIA Parakeet NIM HTTP API exposes a transcription endpoint, but the
 served DGX Spark profile does not accept arbitrary OpenAI-style model names; it
 selects the model by language/profile. This shim keeps clients on the normal
 OpenAI audio API shape while forwarding the request Parakeet actually accepts.
+
+Streaming: when the request sets ``stream=true`` the response is Server-Sent
+Events (``text/event-stream``) in OpenAI's transcription format —
+``transcript.text.delta`` fragments followed by a terminal
+``transcript.text.done`` carrying the full text — so OpenAI clients work
+unmodified. The served NIM profile is offline (``mode=ofl``, one-shot HTTP),
+so there are no native partial hypotheses to proxy; the shim runs the same
+one-shot recognition and replays the final transcript as word-level deltas.
+The non-streaming path is unchanged.
 """
 
+import json
 import os
+import re
+from collections.abc import AsyncIterator
 from typing import Annotated
 
 import httpx
 import uvicorn
 from fastapi import FastAPI, File, Form, HTTPException, Response, UploadFile
+from fastapi.responses import StreamingResponse
 
 DEFAULT_LANGUAGE = os.environ.get("PARAKEET_LANGUAGE", "en-US")
 UPSTREAM_URL = os.environ["PARAKEET_UPSTREAM_URL"].rstrip("/")
@@ -25,6 +38,48 @@ def _as_text(payload: object) -> str:
         text = payload.get("text", "")
         return text if isinstance(text, str) else str(text)
     return str(payload)
+
+
+async def _transcribe(
+    audio: bytes,
+    filename: str,
+    content_type: str,
+    language: str | None,
+    prompt: str | None,
+    temperature: float | None,
+) -> str:
+    """Run one-shot recognition against the Parakeet NIM and return the text."""
+    data: dict[str, str] = {
+        "language": language or DEFAULT_LANGUAGE,
+        "response_format": "json",
+    }
+    if prompt:
+        data["prompt"] = prompt
+    if temperature is not None:
+        data["temperature"] = str(temperature)
+
+    files = {"file": (filename, audio, content_type)}
+    try:
+        async with httpx.AsyncClient(timeout=TIMEOUT_SECONDS) as client:
+            upstream = await client.post(UPSTREAM_URL, data=data, files=files)
+    except httpx.HTTPError as exc:
+        raise HTTPException(502, f"Parakeet upstream request failed: {exc}") from exc
+
+    if upstream.status_code >= 400:
+        raise HTTPException(upstream.status_code, upstream.text)
+
+    try:
+        payload = upstream.json()
+    except ValueError as exc:
+        raise HTTPException(
+            502, "Parakeet upstream returned non-JSON response"
+        ) from exc
+
+    return _as_text(payload).strip()
+
+
+def _sse(event: dict[str, str]) -> str:
+    return f"data: {json.dumps(event)}\n\n"
 
 
 @app.get("/v1/health/ready")
@@ -42,43 +97,36 @@ async def transcriptions(
     prompt: Annotated[str | None, Form()] = None,
     response_format: Annotated[str | None, Form()] = "json",
     temperature: Annotated[float | None, Form()] = None,
+    stream: Annotated[bool | None, Form()] = None,
 ) -> Response | dict[str, str]:
     del model  # Compatibility field only; raw Parakeet NIM rejects arbitrary model ids.
 
     audio = await file.read()
-    data: dict[str, str] = {
-        "language": language or DEFAULT_LANGUAGE,
-        "response_format": "json",
-    }
-    if prompt:
-        data["prompt"] = prompt
-    if temperature is not None:
-        data["temperature"] = str(temperature)
+    filename = file.filename or "audio"
+    content_type = file.content_type or "application/octet-stream"
 
-    files = {
-        "file": (
-            file.filename or "audio",
-            audio,
-            file.content_type or "application/octet-stream",
+    # Resolve the transcript up front so upstream failures surface as normal
+    # HTTP errors instead of mid-stream; the offline NIM yields no partials.
+    text = await _transcribe(
+        audio, filename, content_type, language, prompt, temperature
+    )
+
+    if stream:
+        # OpenAI streaming-transcription SSE: incremental transcript.text.delta
+        # fragments (concatenating to the full text), then a terminal
+        # transcript.text.done. Fragments preserve trailing whitespace so a
+        # client that joins deltas reconstructs the transcript exactly.
+        async def events() -> AsyncIterator[str]:
+            for fragment in re.findall(r"\S+\s*", text):
+                yield _sse({"type": "transcript.text.delta", "delta": fragment})
+            yield _sse({"type": "transcript.text.done", "text": text})
+
+        return StreamingResponse(
+            events(),
+            media_type="text/event-stream",
+            headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
         )
-    }
-    try:
-        async with httpx.AsyncClient(timeout=TIMEOUT_SECONDS) as client:
-            upstream = await client.post(UPSTREAM_URL, data=data, files=files)
-    except httpx.HTTPError as exc:
-        raise HTTPException(502, f"Parakeet upstream request failed: {exc}") from exc
 
-    if upstream.status_code >= 400:
-        raise HTTPException(upstream.status_code, upstream.text)
-
-    try:
-        payload = upstream.json()
-    except ValueError as exc:
-        raise HTTPException(
-            502, "Parakeet upstream returned non-JSON response"
-        ) from exc
-
-    text = _as_text(payload).strip()
     fmt = (response_format or "json").lower()
     if fmt == "text":
         return Response(text, media_type="text/plain")

--- a/nix/systems/aarch64-linux/spark/parakeet-openai-shim.py
+++ b/nix/systems/aarch64-linux/spark/parakeet-openai-shim.py
@@ -40,6 +40,25 @@ def _as_text(payload: object) -> str:
     return str(payload)
 
 
+def _normalize_language(lang: str | None) -> str:
+    """Map a client language code to a locale the NIM actually serves.
+
+    The DGX Spark Parakeet profile loads specific locales (e.g. ``en-US``) and
+    returns 404 "Model not found for language <x>" for bare/alias codes like
+    ``en`` — which is exactly what Home Assistant sends. When the requested
+    language shares its base language with the configured default
+    (``DEFAULT_LANGUAGE``), use the default's full locale so those clients work.
+    Genuinely different languages pass through unchanged (the NIM rejects the
+    ones it has no model for, which is the correct, honest failure).
+    """
+    lang = (lang or "").strip()
+    if not lang:
+        return DEFAULT_LANGUAGE
+    if lang.split("-")[0].lower() == DEFAULT_LANGUAGE.split("-")[0].lower():
+        return DEFAULT_LANGUAGE
+    return lang
+
+
 async def _transcribe(
     audio: bytes,
     filename: str,
@@ -50,7 +69,7 @@ async def _transcribe(
 ) -> str:
     """Run one-shot recognition against the Parakeet NIM and return the text."""
     data: dict[str, str] = {
-        "language": language or DEFAULT_LANGUAGE,
+        "language": _normalize_language(language),
         "response_format": "json",
     }
     if prompt:


### PR DESCRIPTION
## Summary
- Bind `kokoro-openai` (TTS, `:8101`) and the `parakeet-openai` STT shim (`:8102`) to `0.0.0.0` instead of the vasyl tap edge (`10.77.0.1`), so the OpenAI-compatible voice endpoints are reachable from the LAN (e.g. `192.168.0.172`) and the Tailnet — not just the microVM.
- Mirrors how Ollama is already exposed on this host; the firewall is off by design, so no port rules are needed.
- The raw Parakeet NIM stays loopback-only (`127.0.0.1:9000`) — the shim remains its only exposed face. vasyl is unaffected since `0.0.0.0` still covers `10.77.0.1`.

## Test plan
- `nix eval .#nixosConfigurations.spark.config.system.build.toplevel` succeeds; `KOKORO_HOST`/`PARAKEET_HOST` render as `0.0.0.0`.
- Deployed to spark; verified `curl http://192.168.0.172:8101/v1/audio/speech` (TTS) and `http://192.168.0.172:8102/v1/audio/transcriptions` (STT) answer over the LAN.

> Note: committed unsigned per the standing GPG-off preference; `main` requires verified signatures, so merge via a path that produces one (e.g. GitHub web merge).