### PR TITLE
vasyl: promote opencode-go default to kimi-k2.7-code

### DIFF
--- a/nix/systems/aarch64-linux/vasyl/default.nix
+++ b/nix/systems/aarch64-linux/vasyl/default.nix
@@ -205,9 +205,16 @@ in
           default = "gpt-5.5";
         };
         fallback_providers = [
+          # OpenCode Go: pick the best ZDR module. The Go plan routes every
+          # model through a zero-retention policy with no per-model exceptions
+          # (per opencode.ai/go privacy FAQ and the platform-wide X post
+          # declaring ZDR agreements with all Go providers), so ZDR strength
+          # is uniform across the lineup. The discriminator is capability:
+          # Kimi K2.7 Code is the code-specialized successor to K2.6 and the
+          # best fit for the engineering workload on this VM.
           {
             provider = "opencode-go";
-            model = "kimi-k2.6";
+            model = "kimi-k2.7-code";
           }
           {
             provider = "custom";


### PR DESCRIPTION
## Summary
- switches the `opencode-go` fallback entry from `kimi-k2.6` to `kimi-k2.7-code`
- keeps the primary route (`openai-codex` / `gpt-5.5`) unchanged
- keeps Vasyl auxiliary compression/smart-approval defaults on `opencode-go` / `deepseek-v4-flash` from #20
- adds a short comment explaining the ZDR/capability rationale

## Why this model
The OpenCode Go plan offers a uniform zero-retention policy across Go models, so ZDR strength does not distinguish the Go lineup. The discriminator for the main fallback route is capability: `kimi-k2.7-code` is the code-specialized successor to K2.6 and a better fit for the engineering fallback slot.

## Test plan
- [x] `git diff --check`
- [x] `nixfmt --check nix/systems/aarch64-linux/vasyl/default.nix`
- [x] pre-commit hooks from `git commit`: cspell, deadnix, editorconfig-checker, statix, treefmt
- [x] `nix eval` Vasyl first fallback provider resolves to `opencode-go` / `kimi-k2.7-code`
- [x] `nix eval` Vasyl auxiliary compression + approval remain `opencode-go` / `deepseek-v4-flash`
- [x] `nix eval --raw .#nixosConfigurations.vasyl.config.system.build.toplevel.drvPath`
- [ ] GitHub Actions after the latest push

## Risk
Small. One declarative fallback model string plus documentation comment; primary GPT-5.5 route and auxiliary DeepSeek Flash routing are unchanged.

Assisted-by: vasyl
