### PR TITLE
vasyl/spark: switch compression to qwen3:4b, bump ollama context→262K

### DIFF
--- a/nix/systems/aarch64-linux/spark/default.nix
+++ b/nix/systems/aarch64-linux/spark/default.nix
@@ -351,14 +351,17 @@ in
       # (~24 GB on disk, down from the old q8_0's ~39 GB) — ample headroom in
       # the GB10's 128 GiB unified memory beside vasyl's 32 GiB and the KV
       # cache. Same 35B-A3B arch, so the qwen3.6 tool-parser patch still applies.
+      # qwen3:4b-instruct-2507 (Q4_K_M, ~2.5 GB) runs compression: 256K native
+      # context, light enough to keep warm beside the 35B primary.
       loadModels = [
         "huihui_ai/Qwen3.6-abliterated:35b-Claude-4.7"
+        "qwen3:4b-instruct-2507-q4_K_M"
         "gpt-oss:20b"
       ];
 
       environmentVariables = {
         # Hermes hard-requires >=64K; vasyl's context_length must match.
-        OLLAMA_CONTEXT_LENGTH = "131072";
+        OLLAMA_CONTEXT_LENGTH = "262144";
         # Off by default; prerequisite for KV-cache quantization below,
         # which halves KV memory (~2.7 → ~1.35 GB at 128K).
         OLLAMA_FLASH_ATTENTION = "1";

--- a/nix/systems/aarch64-linux/vasyl/default.nix
+++ b/nix/systems/aarch64-linux/vasyl/default.nix
@@ -18,9 +18,11 @@ let
   # MoE small-active arch, the only way to be both smart and fast on the GB10's
   # 273 GB/s: the A3B primary runs ~35–50 tok/s where a dense 27B crawls at
   # ~10–14. The gpt-oss:20b fallback also absorbs qwen3.6 tool-parser 500s
-  # (ollama#16383, patched on spark) and runs compression.
+  # ~10–14. Keep gpt-oss:20b as a local fallback for parser/runtime quirks, but
+  # use Qwen3-4B-2507 for compression: 256K native context at ~2.5 GB Q4_K_M.
   ollamaModel = "huihui_ai/Qwen3.6-abliterated:35b-Claude-4.7";
   fallbackModel = "gpt-oss:20b";
+  compressionModel = "qwen3:4b-instruct-2507-q4_K_M";
   ollamaBaseUrl = "http://${hostAddress}:11434/v1";
 
   # VM-local secret env file — nothing secret in Nix, no secret-management
@@ -215,7 +217,7 @@ in
             # Hermes auto-detects the model MAX (262144) from /v1/models, not the
             # server's effective window — must match spark's OLLAMA_CONTEXT_LENGTH
             # or compression fires too late and requests overflow.
-            context_length = 131072;
+            context_length = 262144;
             supports_vision = true;
           }
           {
@@ -223,7 +225,7 @@ in
             model = fallbackModel;
             base_url = ollamaBaseUrl;
             api_key = "ollama";
-            context_length = 131072;
+            context_length = 262144;
           }
         ];
         # Give Hermes' /model picker a named row for spark's Ollama endpoint.
@@ -241,7 +243,7 @@ in
         auxiliary = {
           compression = {
             provider = "custom";
-            model = fallbackModel;
+            model = compressionModel;
             base_url = ollamaBaseUrl;
             timeout = 240;
           };


### PR DESCRIPTION
## What

- **spark**: pull `qwen3:4b-instruct-2507` Q4_K_M (~2.5 GB, 256K native context) into `loadModels` and raise `OLLAMA_CONTEXT_LENGTH` 131072→262144. qwen3:4b is light enough to keep warm beside the 35B primary while giving the compression model headroom.
- **vasyl**: switch auxiliary compression model from `gpt-oss:20b` to `qwen3:4b-instruct-2507-q4_K_M`. Keeps `gpt-oss:20b` as the secondary fallback for parser/runtime quirks. Bump `context_length` on both ollama providers 131072→262144 to stay aligned with the server effective limit — without this, compression fires too late and requests overflow.

## Why

- `gpt-oss:20b` at 128K context was the compression bottleneck — 20B dense model, limited headroom.
- `qwen3:4b-2507` Q4_K_M: 256K native context, ~2.5 GB on disk, faster warm-up on the always-loaded GPU, better compression quality from the larger window.
- The context_length bump prevents Hermes from requesting compression too late (mismatch between vasyl's declared limit and spark's OLLAMA_CONTEXT_LENGTH).

Assisted-by: vasyl