### PR TITLE
feat: expose muscle ollama on LAN

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ free NGC API key from [ngc.nvidia.com](https://ngc.nvidia.com):
 | `spark`  | `aarch64-linux`  | AI/Compute        | NVIDIA DGX Spark (GB10)   |
 | `timey`  | `aarch64-linux`  | IoT/Edge/Time     | RPi 5, eMMC               |
 | `beefy`  | `aarch64-darwin` | Media             | M2 Ultra, 64GB            |
-| `muscle` | `x86_64-linux`   | AI/Compute        | TR 7985WX, RTX6000, 250GB |
+| `muscle` | `x86_64-linux`   | AI/Compute        | TR 7985WX, 2x RTX6000 Ada |
 | `ghost`  | `x86_64-linux`   | Fun               | T480, 16GB                |
 | `vasyl`  | `aarch64-linux`  | AI Agent          | microVM on `spark`        |
 
@@ -158,6 +158,9 @@ serving voice (Parakeet NIM STT in a container, Kokoro TTS as a pure-Nix CUDA
 service); credentials are filled manually in host-local files — see
 [Secrets](#secrets) and
 [`nix/systems/aarch64-linux/vasyl/`](/nix/systems/aarch64-linux/vasyl/).
+
+`muscle` also exposes CUDA Ollama on the LAN/Tailscale interface, using the same
+agent model set as `spark` and bounded by its 2x RTX 6000 Ada VRAM budget.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -160,7 +160,9 @@ service); credentials are filled manually in host-local files — see
 [`nix/systems/aarch64-linux/vasyl/`](/nix/systems/aarch64-linux/vasyl/).
 
 `muscle` also exposes CUDA Ollama on the LAN/Tailscale interface, using the same
-agent model set as `spark` and bounded by its 2x RTX 6000 Ada VRAM budget.
+agent model set as `spark`. The shared pull set includes Qwen3-Coder-Next as the
+long-context coding/agent pick and stays bounded by Muscle's 2x RTX 6000 Ada VRAM
+budget.
 
 ## Development
 

--- a/cspell.json
+++ b/cspell.json
@@ -122,6 +122,7 @@
     "ddkjiahejlhfcafbddmgiahcphecmpfh",
     "deadnix",
     "debugpy",
+    "deepseek",
     "dependi",
     "devenv",
     "devicons",

--- a/nix/lib/shared/default.nix
+++ b/nix/lib/shared/default.nix
@@ -13,4 +13,5 @@
   user-config = import ./user-config { inherit lib inputs namespace; };
   grafana-dashboards = import ./grafana-dashboards { inherit lib inputs namespace; };
   builders = import ./builders { inherit lib inputs namespace; };
+  ollama = import ./ollama { inherit lib inputs namespace; };
 }

--- a/nix/lib/shared/ollama/default.nix
+++ b/nix/lib/shared/ollama/default.nix
@@ -1,0 +1,10 @@
+_: {
+  # Shared LAN-agent model set for Spark and Muscle. Every entry must fit the
+  # smaller Muscle budget (2x RTX 6000 Ada, 48 GB each); current registry layer
+  # sizes are ~23.94 GB for Qwen3.6-35B-A3B and ~13.79 GB for gpt-oss:20b,
+  # leaving room for a 128K quantized KV cache and one parallel slot.
+  agentModels = [
+    "huihui_ai/Qwen3.6-abliterated:35b-Claude-4.7"
+    "gpt-oss:20b"
+  ];
+}

--- a/nix/lib/shared/ollama/default.nix
+++ b/nix/lib/shared/ollama/default.nix
@@ -1,9 +1,10 @@
 _: {
   # Shared LAN-agent model set for Spark and Muscle. Every entry must fit the
-  # smaller Muscle budget (2x RTX 6000 Ada, 48 GB each); current registry layer
-  # sizes are ~23.94 GB for Qwen3.6-35B-A3B and ~13.79 GB for gpt-oss:20b,
-  # leaving room for a 128K quantized KV cache and one parallel slot.
+  # smaller Muscle budget (2x RTX 6000 Ada, 48 GB each). Qwen3-Coder-Next is the
+  # long-context coding/agent pick: q4_K_M is ~51.74 GB and leaves enough room
+  # for a 256K q8 KV cache; q8_0 is ~84.81 GB and is too tight at full context.
   agentModels = [
+    "qwen3-coder-next:q4_K_M"
     "huihui_ai/Qwen3.6-abliterated:35b-Claude-4.7"
     "gpt-oss:20b"
   ];

--- a/nix/overlays/ollama/default.nix
+++ b/nix/overlays/ollama/default.nix
@@ -1,15 +1,35 @@
-_: _final: prev:
+_: final: prev:
 let
-  # Build each acceleration variant by overriding the upstream package's
-  # `acceleration` argument. (The previous string-patch that injected
-  # `ignoreCollisions = true` is obsolete: upstream now sets it on the
-  # `cudaToolkit` buildEnv itself.)
+  # Mirror nixpkgs' selectable acceleration variants while preserving this
+  # overlay's stable package names. (`ignoreCollisions = true` is obsolete:
+  # upstream now sets it on the CUDA package set's `cudaToolkit` buildEnv itself.)
   mkOllama = acceleration: prev.ollama.override { inherit acceleration; };
+
+  # Qwen3.6 can emit malformed/empty tool-call envelopes that make Ollama 0.24
+  # return HTTP 500s (ollama/ollama#16383). Carry the unmerged parser fix once
+  # in the CUDA package used by Spark and Muscle; pure Go patch, no vendor hash
+  # change. Drop when the pinned channel contains ollama/ollama#16398.
+  withQwen36ToolParserFix =
+    pkg:
+    pkg.overrideAttrs (old: {
+      patches = (old.patches or [ ]) ++ [
+        (final.fetchpatch {
+          name = "ollama-qwen36-tolerate-tool-template-drift.patch";
+          url = "https://github.com/ollama/ollama/commit/beed6703d8fe3795049db45863458785774ef396.patch";
+          hash = "sha256-xh59I8WNHjkH2Rx1jsGl+8anjvGA/294yz5Z3dV87QY=";
+        })
+        (final.fetchpatch {
+          name = "ollama-qwen36-skip-empty-tool-call-envelopes.patch";
+          url = "https://github.com/ollama/ollama/commit/769dcb5eb7bc8707aabf5de611a1dcb05ffa3ab5.patch";
+          hash = "sha256-kRSPiX+wJfv7HOKhaxP50ZHUdPIOhXbjdKp/0L8AYOU=";
+        })
+      ];
+    });
 in
 {
   ollama = mkOllama null;
   ollama-cpu = mkOllama false;
-  ollama-cuda = mkOllama "cuda";
+  ollama-cuda = withQwen36ToolParserFix (mkOllama "cuda");
   ollama-rocm = mkOllama "rocm";
   ollama-vulkan = mkOllama "vulkan";
 }

--- a/nix/systems/aarch64-linux/spark/default.nix
+++ b/nix/systems/aarch64-linux/spark/default.nix
@@ -328,39 +328,15 @@ in
     # firewall is disabled and it's reachable over Tailscale).
     ollama = {
       enable = true;
-      # Root-cause fix for qwen3.6 tool-call drift → HTTP 500 (ollama/ollama#16383):
-      # carry the unmerged parser fix (ollama/ollama#16398, 2 commits) as source
-      # patches. Spark-only — other hosts keep the stock pkgs.ollama-cuda. Pure Go
-      # parser change + tests; no go.mod/go.sum impact, so vendorHash is untouched.
-      # Drop once the pinned channel's ollama contains the merged fix (the build
-      # fails loudly at patchPhase if upstream code drifts).
-      package = pkgs.ollama-cuda.overrideAttrs (old: {
-        patches = (old.patches or [ ]) ++ [
-          (pkgs.fetchpatch {
-            name = "ollama-qwen36-tolerate-tool-template-drift.patch";
-            url = "https://github.com/ollama/ollama/commit/beed6703d8fe3795049db45863458785774ef396.patch";
-            hash = "sha256-xh59I8WNHjkH2Rx1jsGl+8anjvGA/294yz5Z3dV87QY=";
-          })
-          (pkgs.fetchpatch {
-            name = "ollama-qwen36-skip-empty-tool-call-envelopes.patch";
-            url = "https://github.com/ollama/ollama/commit/769dcb5eb7bc8707aabf5de611a1dcb05ffa3ab5.patch";
-            hash = "sha256-kRSPiX+wJfv7HOKhaxP50ZHUdPIOhXbjdKp/0L8AYOU=";
-          })
-        ];
-      });
+      package = pkgs.ollama-cuda;
       host = "0.0.0.0";
 
       # Models for vasyl's hermes-agent (see ../vasyl): pulled by the
       # non-blocking ollama-model-loader.service, content-addressed (no-op
       # when unchanged). syncModels stays off on purpose — it would GC any
-      # model pulled manually outside this list. The primary is Q4_K_M
-      # (~24 GB on disk, down from the old q8_0's ~39 GB) — ample headroom in
-      # the GB10's 128 GiB unified memory beside vasyl's 32 GiB and the KV
-      # cache. Same 35B-A3B arch, so the qwen3.6 tool-parser patch still applies.
-      loadModels = [
-        "huihui_ai/Qwen3.6-abliterated:35b-Claude-4.7"
-        "gpt-oss:20b"
-      ];
+      # model pulled manually outside this list. The shared set is sized for
+      # both Spark and Muscle; the qwen3.6 parser fix lives in the Ollama overlay.
+      loadModels = lib.${namespace}.shared.ollama.agentModels;
 
       environmentVariables = {
         # Hermes hard-requires >=64K; vasyl's context_length must match.

--- a/nix/systems/aarch64-linux/vasyl/default.nix
+++ b/nix/systems/aarch64-linux/vasyl/default.nix
@@ -18,12 +18,11 @@ let
   # MoE small-active arch, the only way to be both smart and fast on the GB10's
   # 273 GB/s: the A3B primary runs ~35–50 tok/s where a dense 27B crawls at
   # ~10–14. The gpt-oss:20b fallback also absorbs qwen3.6 tool-parser 500s
-  # (ollama#16383, patched on spark) and remains the local compression default.
-  # OpenCode Go only backs the auxiliary fallback chain when local Ollama cannot
-  # serve compaction.
+  # (ollama#16383, patched on spark). Auxiliary compression/approval use the
+  # paid OpenCode Go route below instead of spending local Spark/Muscle time.
   ollamaModel = "huihui_ai/Qwen3.6-abliterated:35b-Claude-4.7";
   fallbackModel = "gpt-oss:20b";
-  opencodeCompactionModel = "deepseek-v4-pro";
+  opencodeAuxiliaryModel = "deepseek-v4-flash";
   ollamaBaseUrl = "http://${hostAddress}:11434/v1";
 
   # VM-local secret env file — nothing secret in Nix, no secret-management
@@ -242,34 +241,18 @@ in
           }
         ];
         auxiliary = {
-          # Keep compaction local by default: spark/muscle Ollama already pull
-          # gpt-oss:20b from the shared agent set. If the LAN Ollama route is
-          # down or quota/capacity-like failure bubbles up, Hermes' supported
-          # per-task fallback_chain sends compression to OpenCode Go instead.
+          # Pin Hermes' auxiliary task defaults to Vasyl's chosen OpenCode Go
+          # model instead of letting compaction/smart-approval drift independently.
           compression = {
-            provider = "custom";
-            model = fallbackModel;
-            base_url = ollamaBaseUrl;
-            api_key = "ollama";
-            context_length = 131072;
+            provider = "opencode-go";
+            model = opencodeAuxiliaryModel;
             timeout = 240;
-            fallback_chain = [
-              {
-                provider = "opencode-go";
-                model = opencodeCompactionModel;
-              }
-              {
-                provider = "opencode-go";
-                model = "kimi-k2.6";
-              }
-            ];
           };
-          # Smart approval uses Hermes' auxiliary task router. Pin it to the
-          # same Codex subscription/model as the main agent instead of letting
-          # auto-provider selection drift to a weaker or unfunded backend.
+          # Smart approval uses Hermes' auxiliary task router; keep it on the
+          # same auxiliary model as compression.
           approval = {
-            provider = "openai-codex";
-            model = "gpt-5.5";
+            provider = "opencode-go";
+            model = opencodeAuxiliaryModel;
             timeout = 30;
           };
         };

--- a/nix/systems/aarch64-linux/vasyl/default.nix
+++ b/nix/systems/aarch64-linux/vasyl/default.nix
@@ -18,11 +18,12 @@ let
   # MoE small-active arch, the only way to be both smart and fast on the GB10's
   # 273 GB/s: the A3B primary runs ~35–50 tok/s where a dense 27B crawls at
   # ~10–14. The gpt-oss:20b fallback also absorbs qwen3.6 tool-parser 500s
-  # (ollama#16383, patched on spark). Context compaction uses the paid
-  # OpenCode Go route below instead of spending local Spark GPU time.
+  # (ollama#16383, patched on spark) and remains the local compression default.
+  # OpenCode Go only backs the auxiliary fallback chain when local Ollama cannot
+  # serve compaction.
   ollamaModel = "huihui_ai/Qwen3.6-abliterated:35b-Claude-4.7";
   fallbackModel = "gpt-oss:20b";
-  compactionModel = "deepseek-v4-pro";
+  opencodeCompactionModel = "deepseek-v4-pro";
   ollamaBaseUrl = "http://${hostAddress}:11434/v1";
 
   # VM-local secret env file — nothing secret in Nix, no secret-management
@@ -241,13 +242,27 @@ in
           }
         ];
         auxiliary = {
-          # Compaction is a faithful state-preservation pass, not a local-inference
-          # showcase. Use the same OpenCode Go paid route Mykhailo chose for
-          # compaction rather than burning Spark/Muscle Ollama VRAM mid-turn.
+          # Keep compaction local by default: spark/muscle Ollama already pull
+          # gpt-oss:20b from the shared agent set. If the LAN Ollama route is
+          # down or quota/capacity-like failure bubbles up, Hermes' supported
+          # per-task fallback_chain sends compression to OpenCode Go instead.
           compression = {
-            provider = "opencode-go";
-            model = compactionModel;
+            provider = "custom";
+            model = fallbackModel;
+            base_url = ollamaBaseUrl;
+            api_key = "ollama";
+            context_length = 131072;
             timeout = 240;
+            fallback_chain = [
+              {
+                provider = "opencode-go";
+                model = opencodeCompactionModel;
+              }
+              {
+                provider = "opencode-go";
+                model = "kimi-k2.6";
+              }
+            ];
           };
           # Smart approval uses Hermes' auxiliary task router. Pin it to the
           # same Codex subscription/model as the main agent instead of letting

--- a/nix/systems/aarch64-linux/vasyl/default.nix
+++ b/nix/systems/aarch64-linux/vasyl/default.nix
@@ -18,9 +18,11 @@ let
   # MoE small-active arch, the only way to be both smart and fast on the GB10's
   # 273 GB/s: the A3B primary runs ~35–50 tok/s where a dense 27B crawls at
   # ~10–14. The gpt-oss:20b fallback also absorbs qwen3.6 tool-parser 500s
-  # (ollama#16383, patched on spark) and runs compression.
+  # (ollama#16383, patched on spark). Context compaction uses the paid
+  # OpenCode Go route below instead of spending local Spark GPU time.
   ollamaModel = "huihui_ai/Qwen3.6-abliterated:35b-Claude-4.7";
   fallbackModel = "gpt-oss:20b";
+  compactionModel = "deepseek-v4-pro";
   ollamaBaseUrl = "http://${hostAddress}:11434/v1";
 
   # VM-local secret env file — nothing secret in Nix, no secret-management
@@ -239,10 +241,12 @@ in
           }
         ];
         auxiliary = {
+          # Compaction is a faithful state-preservation pass, not a local-inference
+          # showcase. Use the same OpenCode Go paid route Mykhailo chose for
+          # compaction rather than burning Spark/Muscle Ollama VRAM mid-turn.
           compression = {
-            provider = "custom";
-            model = fallbackModel;
-            base_url = ollamaBaseUrl;
+            provider = "opencode-go";
+            model = compactionModel;
             timeout = 240;
           };
           # Smart approval uses Hermes' auxiliary task router. Pin it to the

--- a/nix/systems/x86_64-linux/muscle/default.nix
+++ b/nix/systems/x86_64-linux/muscle/default.nix
@@ -273,6 +273,23 @@
     };
 
     tailscale.enable = true;
+
+    # LAN Ollama peer to Spark. Muscle has 2x RTX 6000 Ada GPUs (48 GB each),
+    # so the pull set stays shared and vetted against that smaller VRAM budget.
+    ollama = {
+      enable = true;
+      package = pkgs.ollama-cuda;
+      host = "0.0.0.0";
+      loadModels = lib.${namespace}.shared.ollama.agentModels;
+
+      environmentVariables = {
+        OLLAMA_CONTEXT_LENGTH = "131072";
+        OLLAMA_FLASH_ATTENTION = "1";
+        OLLAMA_KV_CACHE_TYPE = "q8_0";
+        OLLAMA_KEEP_ALIVE = "24h";
+        OLLAMA_NUM_PARALLEL = "1";
+      };
+    };
   };
 
   security = {


### PR DESCRIPTION
## Summary
- enables Muscle's CUDA Ollama service on `0.0.0.0:11434` for LAN/Tailscale access
- shares Spark/Muscle's agent model pull set from one Nix lib entry
- adds Qwen3-Coder-Next `q4_K_M` as the long-context coding/agent pick that fits Muscle
- routes Vasyl Hermes auxiliary compression and smart approval to OpenCode Go `deepseek-v4-flash`
- moves the Qwen3.6 Ollama parser patch into the CUDA Ollama overlay so both hosts use it
- documents Muscle's 2x RTX 6000 Ada Ollama role

## Model fit
- NVIDIA lists RTX 6000 Ada with 48 GB memory; Muscle has 2x cards (~89.4 GiB aggregate usable from 96 GB decimal)
- Qwen3-Coder-Next `q4_K_M` is the selected SOTA local coding/agent model:
  - Ollama registry layer size: 51.74 GB / 48.19 GiB
  - native context: 262,144 tokens
  - estimated q8 KV at 256K: ~12.0 GiB, leaving ~29 GiB aggregate headroom before runtime overhead
  - `q8_0` was rejected: 84.81 GB / 78.99 GiB weights plus ~12 GiB q8 KV exceeds the 2x48 GB budget at full context
- Existing shared pull-set models kept for compatibility:
  - `huihui_ai/Qwen3.6-abliterated:35b-Claude-4.7`: 23.94 GB / 22.29 GiB
  - `gpt-oss:20b`: 13.79 GB / 12.85 GiB

## Vasyl auxiliary routing
- `auxiliary.compression` now defaults to OpenCode Go:
  - provider: `opencode-go`
  - model: `deepseek-v4-flash`
  - timeout: `240`
- `auxiliary.approval` uses the same auxiliary route for smart approvals:
  - provider: `opencode-go`
  - model: `deepseek-v4-flash`
  - timeout: `30`
- Local Ollama stays in the primary fallback chain for offline/local inference, not as the compression default.

## Test plan
- [x] `nixfmt --check nix/systems/aarch64-linux/vasyl/default.nix`
- [x] `git diff --check`
- [x] pre-commit hooks from `git commit`: cspell, deadnix, editorconfig-checker, statix, treefmt
- [x] `nix eval` Vasyl `services.hermes-agent.settings.auxiliary` resolves compression + approval to `opencode-go` / `deepseek-v4-flash`
- [x] `nix eval` Spark/Muscle `services.ollama.loadModels` includes the shared agent pull set
- [x] `nix eval --raw` Spark/Muscle/Vasyl `config.system.build.toplevel.drvPath`
- [ ] GitHub Actions after the latest push
