### PR TITLE
fix(vasyl): pin Codex compaction threshold

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -34,6 +34,7 @@
     "autohide",
     "autoLoginUser",
     "automount",
+    "autoraise",
     "autopair",
     "autopairs",
     "autostash",

--- a/nix/systems/aarch64-linux/vasyl/default.nix
+++ b/nix/systems/aarch64-linux/vasyl/default.nix
@@ -273,7 +273,11 @@ in
         privacy.redact_pii = true;
         compression = {
           enabled = true;
-          threshold = 0.5;
+          # Vasyl's primary route is Codex gpt-5.5. Hermes would otherwise
+          # auto-raise this to 85% and warn on every new gateway session; make
+          # the desired policy explicit instead of opting out of the auto-raise.
+          threshold = 0.85;
+          codex_gpt55_autoraise = true;
         };
         # Tool exposure is per platform in current Hermes. The legacy
         # top-level `toolsets` key is deprecated/ignored; keep the active

--- a/renovate.json5
+++ b/renovate.json5
@@ -18,9 +18,12 @@
   branchConcurrentLimit: 5,
   rebaseWhen: "behind-base-branch",
   minimumReleaseAge: "3 days",
-  // Automerge by default for non-major updates after required CI checks pass;
-  // major bumps and regex-managed custom sources still require dashboard approval.
+  // Automerge by default for non-major updates after required CI checks pass.
+  // Use GitHub native PR auto-merge explicitly: branch automerge cannot satisfy
+  // the main ruleset's required status checks, but PR auto-merge can queue the
+  // squash merge and let GitHub land it once all checks pass.
   automerge: true,
+  automergeType: "pr",
   platformAutomerge: true,
   automergeStrategy: "squash",
   nix: {
@@ -57,8 +60,11 @@
   ],
   lockFileMaintenance: {
     enabled: true,
+    dependencyDashboardApproval: false,
     automerge: true,
+    automergeType: "pr",
     platformAutomerge: true,
+    automergeStrategy: "squash",
     schedule: ["before 5am"],
   },
   vulnerabilityAlerts: {
@@ -72,6 +78,7 @@
       matchUpdateTypes: ["digest", "patch", "minor"],
       groupName: "github-actions",
       automerge: true,
+      automergeType: "pr",
       platformAutomerge: true,
       automergeStrategy: "squash",
     },
@@ -81,6 +88,7 @@
       matchUpdateTypes: ["lockFileMaintenance", "digest"],
       groupName: "flake lock maintenance",
       automerge: true,
+      automergeType: "pr",
       platformAutomerge: true,
       automergeStrategy: "squash",
     },
@@ -97,6 +105,10 @@
       groupName: "core flake inputs",
       minimumReleaseAge: "3 days",
       schedule: ["before 5am"],
+      automerge: true,
+      automergeType: "pr",
+      platformAutomerge: true,
+      automergeStrategy: "squash",
     },
     {
       description: "Automerge non-major flake updates after CI and security checks pass",
@@ -105,6 +117,7 @@
       matchCurrentVersion: "!/^0/",
       minimumReleaseAge: "3 days",
       automerge: true,
+      automergeType: "pr",
       platformAutomerge: true,
       automergeStrategy: "squash",
     },
@@ -130,6 +143,8 @@
       matchDepNames: ["helium"],
       dependencyDashboardApproval: false,
       automerge: true,
+      automergeType: "pr",
+      platformAutomerge: true,
       automergeStrategy: "squash",
     },
   ],


### PR DESCRIPTION
## Summary
- set Vasyl Hermes compression threshold to 0.85 explicitly while keeping codex_gpt55_autoraise enabled
- enable/verify GitHub repository auto-merge and make Renovate use explicit PR/platform automerge
- make lock-file maintenance bypass dashboard approval and queue squash auto-merge after required checks pass
- add cspell allowlist entry for autoraise

## Verification
- gh repo edit 0x77dev/land --enable-auto-merge --delete-branch-on-merge
- gh api repos/0x77dev/land --jq '{allow_auto_merge,delete_branch_on_merge}'
- nix fmt -- nix/systems/aarch64-linux/vasyl/default.nix
- nix eval --json .#nixosConfigurations.vasyl.config.services.hermes-agent.settings.compression
- nix develop -c prek run --files renovate.json5 cspell.json nix/systems/aarch64-linux/vasyl/default.nix
- /run/current-system/sw/bin/nix shell nixpkgs#bun -c bunx -p renovate renovate-config-validator ./renovate.json5
- RENOVATE_CONFIG_FILE="/var/lib/hermes/workspace/land/renovate.json5" bunx renovate --platform=github --dry-run=lookup 0x77dev/land
- nix flake check --accept-flake-config

Assisted-by: vasyl