### PR TITLE
kanban: enable auto_decompose for autonomous task decomposition

### DIFF
--- a/nix/systems/aarch64-linux/vasyl/default.nix
+++ b/nix/systems/aarch64-linux/vasyl/default.nix
@@ -316,7 +316,7 @@ in
         # profiles and isolated branch routing are deliberately added.
         kanban = {
           dispatch_in_gateway = true;
-          auto_decompose = false;
+          auto_decompose = true;
           max_in_progress_per_profile = 4;
         };
 


### PR DESCRIPTION
The kanban dispatcher should auto-decompose complex tasks into subtasks. Previously disabled pending worker profiles; now needed for the default profile to handle coherent multi-source operations (Craft population, GDrive migration, graph verification).

- Enables `kanban.auto_decompose = true`
- No other config changes
- Pre-commit hooks passed (statix, deadnix, treefmt, editorconfig, cspell)

Assisted-by: vasyl