### PR TITLE
fix(nix): check namespace package builds

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -141,7 +141,7 @@
       };
 
       # Generate base outputs
-      outputs = lib.mkFlake {
+      baseOutputs = lib.mkFlake {
         inherit supportedSystems;
 
         channels-config.allowUnfree = true;
@@ -194,6 +194,24 @@
             ];
           };
         };
+      };
+
+      getSystemPackages =
+        system:
+        if builtins.hasAttr "packages" baseOutputs && builtins.hasAttr system baseOutputs.packages then
+          lib.filterAttrs (_: package: lib.isDerivation package) baseOutputs.packages.${system}
+        else
+          { };
+
+      namespacePackageChecks = lib.genAttrs supportedSystems (
+        system:
+        lib.mapAttrs' (name: package: lib.nameValuePair "package-${name}" package) (
+          getSystemPackages system
+        )
+      );
+
+      outputs = baseOutputs // {
+        checks = lib.recursiveUpdate (baseOutputs.checks or { }) namespacePackageChecks;
       };
 
       automation = outputs.lib.automation.mkOutputs { inherit outputs; };

--- a/nix/packages/helium/default.nix
+++ b/nix/packages/helium/default.nix
@@ -28,19 +28,19 @@ let
   sources = {
     x86_64-linux = {
       url = "${linuxBase}/helium-${version}-x86_64_linux.tar.xz";
-      hash = "sha256-tfiy1MkxXq9vOjp57R3ykHjleG0Viz/C2ttwXbHnPwA=";
+      hash = "sha256-R/cGyWuBrLeFhucrpkRpQN9k/MWN3JlnwSufEsqVkmY=";
     };
     aarch64-linux = {
       url = "${linuxBase}/helium-${version}-arm64_linux.tar.xz";
-      hash = "sha256-q6cCrvDh9eYQZwCLArKXZDpYkl0Zzi2g9gp9l+G+QIA=";
+      hash = "sha256-DSlJxzRAFhTkTyYFyUrypf+leU+Sip2pkLtOuyIduzU=";
     };
     x86_64-darwin = {
       url = "${macosBase}/helium_${version}_x86_64-macos.dmg";
-      hash = "sha256-iJSV5S9LM7Vvpn4g2cdHzgJAqUjBvUfu+izUh5N3mKI=";
+      hash = "sha256-zZH/u/dx3Vuh4wiqMQ/E0kNT/Q4YsBrLfBRX13VEh1k=";
     };
     aarch64-darwin = {
       url = "${macosBase}/helium_${version}_arm64-macos.dmg";
-      hash = "sha256-uws6OUTyV6/Ejo1FqFnpNSG3tTUGFMNelrex2m1Ymd0=";
+      hash = "sha256-4SeQxbnd9nFtWvUOFPbEFgFs1LFongXaA02UI2qfdnA=";
     };
   };
 


### PR DESCRIPTION
## Summary
- refresh Helium 0.13.3.1 fixed-output hashes for all package sources
- expose each Snowfall package output as its own `checks.<system>.package-<name>` derivation instead of one aggregate namespace check
- feed the generated per-package checks into the flake-driven CI matrix so package hash drift fails normal CI with the failing package target visible in the build command/logs

## Generated check targets
- `package-helium`
- `package-gpsd-exporter`
- `package-tx-02-variable`
- `package-cursor-agent` where the package exists for that system

## Verification
- Reproduced current break: `nix build --accept-flake-config .#packages.aarch64-linux.helium --no-link` failed with stale hash `sha256-q6c...` vs `sha256-DSl...`
- `bash scripts/nix-rehash.sh nix/packages/helium/default.nix helium`
- `nix eval --accept-flake-config --json .#checks.aarch64-linux --apply 'builtins.attrNames'`
- `nix eval --accept-flake-config --json .#lib.automation.githubActions.ci.matrix`
- `nix build --accept-flake-config --no-link .#checks.aarch64-linux.package-cursor-agent .#checks.aarch64-linux.package-gpsd-exporter .#checks.aarch64-linux.package-helium .#checks.aarch64-linux.package-tx-02-variable`
- `nix flake check --accept-flake-config`
- `nix flake check --all-systems --no-build --accept-flake-config`
