### PR TITLE
fix(vasyl): overlay ephemeral-fallback patch onto hermes-agent

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -1,7 +1,8 @@
 {
   "ignorePaths": [
     ".cursor/rules",
-    "cloudflare.json"
+    "cloudflare.json",
+    "**/*.patch"
   ],
   "ignoreRegExpList": [
     "[A-Z0-9]{4}-[A-Z0-9]{4}-[A-Z0-9]{4}-[A-Z0-9]{4}"

--- a/nix/systems/aarch64-linux/vasyl/default.nix
+++ b/nix/systems/aarch64-linux/vasyl/default.nix
@@ -198,7 +198,13 @@ in
 
     hermes-agent = {
       enable = true;
-      package = inputs.hermes-agent.packages.${pkgs.stdenv.hostPlatform.system}.full;
+      # Upstream input stays pinned; the ephemeral-fallback fix is overlaid as
+      # a single reviewable patch. Drop this overrideAttrs + the patch file
+      # once the fix lands upstream (NousResearch/hermes-agent). See
+      # patches/hermes-ephemeral-fallback.patch for rationale + test.
+      package = inputs.hermes-agent.packages.${pkgs.stdenv.hostPlatform.system}.full.overrideAttrs (old: {
+        patches = (old.patches or [ ]) ++ [ ./patches/hermes-ephemeral-fallback.patch ];
+      });
 
       # `hermes` CLI on every PATH, sharing HERMES_HOME with the gateway. This
       # also makes config.yaml group-writable (0660) — the module's official

--- a/nix/systems/aarch64-linux/vasyl/patches/hermes-ephemeral-fallback.patch
+++ b/nix/systems/aarch64-linux/vasyl/patches/hermes-ephemeral-fallback.patch
@@ -1,0 +1,39 @@
+diff --git a/hermes_cli/cli_agent_setup_mixin.py b/hermes_cli/cli_agent_setup_mixin.py
+index 1041e8fd0..5dbaa0376 100644
+--- a/hermes_cli/cli_agent_setup_mixin.py
++++ b/hermes_cli/cli_agent_setup_mixin.py
+@@ -35,6 +35,17 @@ class CLIAgentSetupMixin:
+             format_runtime_provider_error,
+         )
+ 
++        # Re-anchor to the configured primary each turn so an automatic
++        # fallback from a previous turn doesn't stick. The fallback path
++        # below sets _auto_fallback_active when it mutates us; here we undo
++        # that mutation so the primary is retried first every turn. Only
++        # auto-fallbacks are reverted — user-initiated /model switches don't
++        # set the flag, so they remain sticky across turns.
++        if getattr(self, "_auto_fallback_active", False):
++            self.requested_provider = self._pre_fallback_provider
++            self.model = self._pre_fallback_model
++            self._auto_fallback_active = False
++
+         _primary_exc = None
+         runtime = None
+         try:
+@@ -63,8 +74,16 @@ class CLIAgentSetupMixin:
+                             _primary_exc, _fb_provider, _fb_model,
+                         )
+                         _cprint(f"⚠️  Primary auth failed — switching to fallback: {_fb_provider} / {_fb_model}")
++                        # Capture the intended primary so the next turn can
++                        # retry it first. Only capture on the first fallback
++                        # of a streak so a re-fallback (primary still down)
++                        # preserves the original primary, not the fallback.
++                        if not getattr(self, "_auto_fallback_active", False):
++                            self._pre_fallback_provider = self.requested_provider
++                            self._pre_fallback_model = self.model
+                         self.requested_provider = _fb_provider
+                         self.model = _fb_model
++                        self._auto_fallback_active = True
+                         _primary_exc = None
+                         break
+                     except Exception:


### PR DESCRIPTION
## What

Applies the ephemeral-fallback fix from upstream PR [NousResearch/hermes-agent#48901](https://github.com/NousResearch/hermes-agent/pull/48901) to the pinned `hermes-agent` flake input via `overrideAttrs`, so the fix ships locally without maintaining a fork.

## Problem

When the primary provider fails with `AuthError`, `_ensure_runtime_credentials()` falls back and mutates the session's `provider`/`model` in place. Because that method runs **per turn** and re-resolves from those attributes, a single transient primary failure (a 403 that recovers seconds later) stranded the session on the fallback **until the gateway restarted** — even after the primary recovered.

## Fix

The overlay patch (identical to the upstream PR) tracks automatic fallbacks via `_auto_fallback_active`: on the next turn, if set, it restores the pre-fallback primary and retries it first. User-initiated `/model` switches don't set the flag and remain sticky.

## How (Nix-idiomatic)

```nix
package = inputs.hermes-agent.packages.${system}.full.overrideAttrs (old: {
  patches = (old.patches or [ ]) ++ [ ./patches/hermes-ephemeral-fallback.patch ];
});
```

Upstream input stays pinned and updatable. The patch is one reviewable file. **Drop this `overrideAttrs` + the patch file once upstream #48901 merges** — the flake bump will carry the fix natively.

## Also

Excludes `**/*.patch` from cspell — patch files are machine-generated diffs; spell-checking them flags code identifiers (`getattr`, `cprint`) as unknown words.

## Verification

- Patch applies cleanly to the pinned rev (`patch -p1 --dry-run` ✓)
- Standalone test passes (turn 1 falls back, turn 2 self-heals to primary); reverting the fix fails the test ✓
- `nix-instantiate --parse` syntax ✓; `overrideAttrs` eval resolved pre-store-corruption ✓
- Pre-commit hooks green (actionlint, cspell, deadnix, editorconfig, statix, treefmt)
- Local full build blocked by an unrelated overlayfs ESTALE on `/nix/store` (affects clean `main` identically) — CI will validate on a clean store

Assisted-by: vasyl