### PR TITLE
fix(vasyl): preserve local Hermes custom providers

### DIFF
--- a/nix/systems/aarch64-linux/vasyl/default.nix
+++ b/nix/systems/aarch64-linux/vasyl/default.nix
@@ -241,18 +241,18 @@ in
           provider = "opencode-go";
           inherit model;
         }) opencodeFallbackModels;
-        # Give Hermes' /model picker a named row for spark's Ollama endpoint.
+        # Give Hermes' /model picker a named row for spark's Ollama endpoint
+        # without owning `custom_providers`: that key is a list, so the NixOS
+        # module's activation merge replaces runtime-added entries. `providers`
+        # is an attribute set and deep-merges with local private provider bridges.
         # This is deliberately manual-only: assertions below fail evaluation if
         # an Ollama/custom provider is reintroduced into automatic fallbacks.
-        custom_providers = [
-          {
-            name = "Ollama";
-            base_url = ollamaBaseUrl;
-            api_key = "ollama";
-            api_mode = "chat_completions";
-            discover_models = true;
-          }
-        ];
+        providers.Ollama = {
+          api = ollamaBaseUrl;
+          api_key = "ollama";
+          transport = "chat_completions";
+          discover_models = true;
+        };
         auxiliary = {
           # Pin every Hermes auxiliary task to DeepSeek V4 Flash on OpenCode Go
           # instead of letting per-task defaults drift to auto, GPT-5.5, or local


### PR DESCRIPTION
## What

Moves Vasyl’s declarative Ollama model-picker entry from the legacy `custom_providers` list to the newer `providers` attribute set.

## Why

The Hermes NixOS activation merge deep-merges attribute sets but replaces lists wholesale. Declaring `custom_providers` in Nix therefore erased runtime-added local provider bridge entries during rebuild/activation. The endpoint and credential for those bridges must remain local mutable state, not public flake data.

`providers` is an attribute set, so the Nix-owned Ollama row can coexist with local provider bridge state without clobbering it.

## Verification

- `nix eval --json .#nixosConfigurations.vasyl.config.services.hermes-agent.settings` shows no `custom_providers` key, keeps the intended primary/fallback/approval route, and includes `providers.Ollama`.
- Simulated the module activation merge with the generated settings and live config: local `custom_providers` entries are preserved and `providers.Ollama` is added.
- `nix build --accept-flake-config --dry-run .#nixosConfigurations.vasyl.config.system.build.toplevel` succeeds.
- Pre-commit hooks pass: cspell, deadnix, editorconfig-checker, statix, treefmt.
- Branch diff leak scan is clean for private endpoint/token/upstream/capacity patterns.

Assisted-by: vasyl