### PR TITLE
feat: add Vercel AI Gateway providers for Vasyl

### DIFF
--- a/nix/systems/aarch64-linux/vasyl/default.nix
+++ b/nix/systems/aarch64-linux/vasyl/default.nix
@@ -253,11 +253,91 @@ in
         # is an attribute set and deep-merges with local private provider bridges.
         # This is deliberately manual-only: assertions below fail evaluation if
         # an Ollama/custom provider is reintroduced into automatic fallbacks.
-        providers.Ollama = {
-          api = ollamaBaseUrl;
-          api_key = "ollama";
-          transport = "chat_completions";
-          discover_models = true;
+        #
+        # Vercel AI Gateway is also one account/key, but Hermes needs one row per
+        # wire protocol so SDK-specific request shapes stay correct: OpenAI Chat
+        # Completions and Responses use /v1, while Anthropic Messages must stop
+        # before the SDK appends /v1/messages. The token lives only in
+        # hermesSecretEnv as AI_GATEWAY_API_KEY.
+        providers = {
+          Ollama = {
+            api = ollamaBaseUrl;
+            api_key = "ollama";
+            transport = "chat_completions";
+            discover_models = true;
+          };
+
+          vercel-ai-gateway-chat = {
+            name = "Vercel AI Gateway (OpenAI Chat Completions)";
+            api = "https://ai-gateway.vercel.sh/v1";
+            key_env = "AI_GATEWAY_API_KEY";
+            transport = "chat_completions";
+            default_model = "openai/gpt-5.5";
+            discover_models = true;
+            models = {
+              "openai/gpt-5.5" = {
+                context_length = 1000000;
+              };
+              "openai/gpt-5.5-pro" = {
+                context_length = 1000000;
+              };
+              "openai/gpt-5.4" = {
+                context_length = 1050000;
+              };
+              "openai/gpt-5-mini" = {
+                context_length = 400000;
+              };
+              "google/gemini-2.5-pro" = {
+                context_length = 1048576;
+              };
+            };
+          };
+
+          vercel-ai-gateway-responses = {
+            name = "Vercel AI Gateway (OpenAI Responses)";
+            api = "https://ai-gateway.vercel.sh/v1";
+            key_env = "AI_GATEWAY_API_KEY";
+            transport = "codex_responses";
+            default_model = "openai/gpt-5.5";
+            discover_models = true;
+            models = {
+              "openai/gpt-5.5" = {
+                context_length = 1000000;
+              };
+              "openai/gpt-5.5-pro" = {
+                context_length = 1000000;
+              };
+              "openai/gpt-5.4" = {
+                context_length = 1050000;
+              };
+              "openai/gpt-5-mini" = {
+                context_length = 400000;
+              };
+            };
+          };
+
+          vercel-ai-gateway-anthropic = {
+            name = "Vercel AI Gateway (Anthropic Messages)";
+            api = "https://ai-gateway.vercel.sh";
+            key_env = "AI_GATEWAY_API_KEY";
+            transport = "anthropic_messages";
+            default_model = "anthropic/claude-sonnet-4.6";
+            discover_models = false;
+            models = {
+              "anthropic/claude-sonnet-4.6" = {
+                context_length = 1000000;
+              };
+              "anthropic/claude-opus-4.8" = {
+                context_length = 1000000;
+              };
+              "anthropic/claude-fable-5" = {
+                context_length = 1000000;
+              };
+              "anthropic/claude-haiku-4.5" = {
+                context_length = 200000;
+              };
+            };
+          };
         };
         auxiliary = {
           # Pin every Hermes auxiliary task to DeepSeek V4 Flash on OpenCode Go

--- a/nix/systems/aarch64-linux/vasyl/default.nix
+++ b/nix/systems/aarch64-linux/vasyl/default.nix
@@ -229,13 +229,13 @@ in
       extraPlugins = [ outboundApprovalPlugin ];
 
       settings = {
-        # Declared default: the private OpenAI-compatible route is named only as
-        # `stealth` here. Its endpoint, real upstream model, and credential live
-        # in Hermes' mutable local config/auth store so the public flake never
-        # exposes more than the routing alias.
+        # Primary route: Vercel AI Gateway via the OpenAI Responses transport.
+        # This keeps the default on GPT-5.5 while giving Hermes one account/key
+        # for OpenAI-compatible, Anthropic, and Gemini gateway models below.
         model = {
-          provider = "stealth";
-          default = "stealth";
+          provider = "vercel-ai-gateway-responses";
+          default = "openai/gpt-5.5";
+          context_length = 1000000;
         };
         fallback_providers = [
           {


### PR DESCRIPTION
## Summary
- add Vercel AI Gateway provider rows for OpenAI Chat Completions, OpenAI Responses, and Anthropic Messages
- keep Gateway auth out of Nix by referencing `AI_GATEWAY_API_KEY` from the VM-local secret env
- preserve Ollama as manual-only under the merge-friendly `providers` attrset

## Verification
- `nixfmt nix/systems/aarch64-linux/vasyl/default.nix`
- `git diff --check`
- `nix eval --accept-flake-config --json .#nixosConfigurations.vasyl.config.services.hermes-agent.settings.providers`
- `nix eval --accept-flake-config --raw .#nixosConfigurations.vasyl.config.system.build.toplevel.drvPath`
- `nix flake check --accept-flake-config --no-build`
- live Hermes CLI probes through Vercel AI Gateway:
  - `vercel-ai-gateway-chat` + `openai/gpt-5.5`
  - `vercel-ai-gateway-responses` + `openai/gpt-5.5`
  - `vercel-ai-gateway-anthropic` + `anthropic/claude-sonnet-4.6`

Assisted-by: vasyl
