### PR TITLE
fix(vasyl): default Hermes to Codex GPT-5.6 Sol

### DIFF
--- a/nix/systems/aarch64-linux/vasyl/default.nix
+++ b/nix/systems/aarch64-linux/vasyl/default.nix
@@ -18,11 +18,17 @@ let
   # on provider-backed models so local Spark/Muscle time is never silently
   # consumed by an automatic retry path.
   opencodeAuxiliaryModel = "deepseek-v4-flash";
-  opencodeFallbackModels = [
-    "deepseek-v4-pro"
-    "kimi-k2.7-code"
-    "kimi-k2.6"
-    "glm-5.1"
+
+  # OpenAI Codex live catalog probe, 2026-07-15:
+  # gpt-5.6-sol / terra / luna, gpt-5.5, gpt-5.4, and gpt-5.4-mini all report
+  # a 272K context window on the OAuth Codex backend. Sol is the primary; Terra
+  # and Luna are same-context sibling fallbacks; 5.5 is the previous stable
+  # large-context route; 5.4-mini is the speed-biased recovery option.
+  codexFallbackModels = [
+    "gpt-5.6-terra"
+    "gpt-5.6-luna"
+    "gpt-5.5"
+    "gpt-5.4-mini"
   ];
   mkOpencodeAuxiliary = timeout: {
     provider = "opencode-go";
@@ -232,24 +238,20 @@ in
       extraPlugins = [ outboundApprovalPlugin ];
 
       settings = {
-        # Primary route: Vercel AI Gateway via the OpenAI Responses transport.
-        # This keeps the default on GPT-5.5 while giving Hermes one account/key
-        # for OpenAI-compatible, Anthropic, and Gemini gateway models below.
+        # Primary route: OpenAI Codex subscription. The live Codex catalog probe
+        # on 2026-07-15 ranks gpt-5.6-sol first and reports a 272K context window
+        # for the 5.6 family on this OAuth backend. Keep automatic fallbacks on
+        # the same provider: same auth surface, same wire protocol, no surprise
+        # local Spark/Muscle consumption.
         model = {
-          provider = "vercel-ai-gateway-responses";
-          default = "openai/gpt-5.5";
-          context_length = 1000000;
+          provider = "openai-codex";
+          default = "gpt-5.6-sol";
+          context_length = 272000;
         };
-        fallback_providers = [
-          {
-            provider = "openai-codex";
-            model = "gpt-5.5";
-          }
-        ]
-        ++ map (model: {
-          provider = "opencode-go";
+        fallback_providers = map (model: {
+          provider = "openai-codex";
           inherit model;
-        }) opencodeFallbackModels;
+        }) codexFallbackModels;
         # Give Hermes' /model picker a named row for spark's Ollama endpoint
         # without owning `custom_providers`: that key is a list, so the NixOS
         # module's activation merge replaces runtime-added entries. `providers`
@@ -391,8 +393,11 @@ in
         privacy.redact_pii = true;
         compression = {
           enabled = true;
-          # Keep the explicit high-water policy; private route capacity details
-          # stay in Hermes' local config/auth state, not in this public flake.
+          # Codex OAuth reports 272K context for the selected 5.6 family and
+          # supporting fallback models. Keep a high-water trigger so long
+          # sessions use the window before summarizing; the legacy
+          # codex_gpt55_autoraise flag remains true for older fallback/manual
+          # gpt-5.5 sessions that rely on Hermes' route-specific override.
           threshold = 0.85;
           codex_gpt55_autoraise = true;
         };

--- a/nix/systems/aarch64-linux/vasyl/default.nix
+++ b/nix/systems/aarch64-linux/vasyl/default.nix
@@ -13,28 +13,40 @@ let
   hostAddress = "10.77.0.1";
   guestAddress = "10.77.0.2";
 
-  # Spark's Ollama endpoint stays available as an explicit `/model` choice, but
-  # it is not a runtime fallback: fallback routing and auxiliary work should stay
-  # on provider-backed models so local Spark/Muscle time is never silently
-  # consumed by an automatic retry path.
-  opencodeAuxiliaryModel = "deepseek-v4-flash";
+  # OpenAI's 2026-07-09 release data puts Luna at 74.6 on the Coding Agent
+  # Index and 51.2 on the broad Intelligence Index, while the Codex rate card
+  # charges one fifth of Sol's credits per token. That is the right quality /
+  # cost tier for bounded auxiliary calls; reasoning effort is raised only for
+  # fidelity- or safety-sensitive tasks below.
+  codexAuxiliaryModel = "gpt-5.6-luna";
+  mkCodexAuxiliary =
+    {
+      timeout,
+      reasoningEffort ? "low",
+    }:
+    {
+      provider = "openai-codex";
+      model = codexAuxiliaryModel;
+      inherit timeout;
+      # The pinned Hermes revision reads this wire-level form; newer revisions
+      # also accept the equivalent reasoning_effort shorthand.
+      extra_body.reasoning = {
+        enabled = true;
+        effort = reasoningEffort;
+      };
+    };
 
   # OpenAI Codex live catalog probe, 2026-07-15:
   # gpt-5.6-sol / terra / luna, gpt-5.5, gpt-5.4, and gpt-5.4-mini all report
-  # a 272K context window on the OAuth Codex backend. Sol is the primary; Terra
-  # and Luna are same-context sibling fallbacks; 5.5 is the previous stable
-  # large-context route; 5.4-mini is the speed-biased recovery option.
+  # a 272K context window on the OAuth Codex backend. Sol is the primary. Keep
+  # failover frontier-class: Terra scores 77.4 and GPT-5.5 scores 76.4 against
+  # Sol's 80 on the Coding Agent Index (55 / 54.8 / 58.9 respectively on the
+  # broad Intelligence Index). Luna and 5.4-mini are auxiliary tiers, not
+  # substitutes for the main agent's intelligence.
   codexFallbackModels = [
     "gpt-5.6-terra"
-    "gpt-5.6-luna"
     "gpt-5.5"
-    "gpt-5.4-mini"
   ];
-  mkOpencodeAuxiliary = timeout: {
-    provider = "opencode-go";
-    model = opencodeAuxiliaryModel;
-    inherit timeout;
-  };
   ollamaBaseUrl = "http://${hostAddress}:11434/v1";
 
   # VM-local secret env file — nothing secret in Nix, no secret-management
@@ -344,28 +356,34 @@ in
             };
           };
         };
-        auxiliary = {
-          # Pin every Hermes auxiliary task to DeepSeek V4 Flash on OpenCode Go
-          # instead of letting per-task defaults drift to auto, GPT-5.5, or local
-          # Ollama routes.
-          compression = mkOpencodeAuxiliary 240;
-          approval = {
-            provider = "stealth";
-            model = "stealth";
-            timeout = 30;
+        auxiliary =
+          let
+            cheap = timeout: mkCodexAuxiliary { inherit timeout; };
+            careful =
+              timeout:
+              mkCodexAuxiliary {
+                inherit timeout;
+                reasoningEffort = "medium";
+              };
+          in
+          {
+            # Luna is OpenAI's fastest/most-affordable GPT-5.6 tier and keeps the
+            # 272K text+image window. Low effort serves short labeling/drafting;
+            # medium is reserved for fidelity, structure, or safety judgments.
+            approval = careful 30;
+            compression = careful 240;
+            curator = careful 600;
+            kanban_decomposer = careful 180;
+            mcp = careful 30;
+            profile_describer = cheap 60;
+            skills_hub = cheap 30;
+            title_generation = cheap 30;
+            triage_specifier = careful 120;
+            vision = (careful 120) // {
+              download_timeout = 30;
+            };
+            web_extract = careful 360;
           };
-          curator = mkOpencodeAuxiliary 600;
-          kanban_decomposer = mkOpencodeAuxiliary 180;
-          mcp = mkOpencodeAuxiliary 30;
-          profile_describer = mkOpencodeAuxiliary 60;
-          skills_hub = mkOpencodeAuxiliary 30;
-          title_generation = mkOpencodeAuxiliary 30;
-          triage_specifier = mkOpencodeAuxiliary 120;
-          vision = (mkOpencodeAuxiliary 120) // {
-            download_timeout = 30;
-          };
-          web_extract = mkOpencodeAuxiliary 360;
-        };
         # High-ceiling mode for deep missions: let the parent agent run long
         # enough to plan, fan out, integrate, verify, and compact instead of
         # stopping mid-orchestration. Cost/safety guardrails remain in the


### PR DESCRIPTION
## Summary
- default Vasyl Hermes to `openai-codex` / `gpt-5.6-sol`
- restrict main-agent failover to frontier-comparable routes: `gpt-5.6-terra` then `gpt-5.5`
- route all 11 supported Hermes auxiliary tasks through `gpt-5.6-luna`
- use low reasoning for short labeling/drafting tasks and medium reasoning for compression, safety review, curation, decomposition, MCP sampling, vision, and web extraction
- pin the Codex OAuth context to the live 272K catalog value and retain the 85% compression trigger

## Why these tiers
OpenAI's GPT-5.6 release reports:

- Coding Agent Index: Sol 80, Terra 77.4, GPT-5.5 76.4, Luna 74.6
- Intelligence Index: Sol 58.9, Terra 55, GPT-5.5 54.8, Luna 51.2
- Codex credits per 1M input/output tokens: Sol 125/750, Terra 62.5/375, Luna 25/150, GPT-5.5 125/750

Terra and GPT-5.5 preserve frontier-class main-agent quality. Luna is the bounded-work tier: one-fifth of Sol's per-token Codex credits, a 272K text+image window, and substantially stronger agentic capability than a conventional flash model.

Sources:
- https://openai.com/index/gpt-5-6/
- https://help.openai.com/en/articles/20001106-codex-rate-card

## Verification
- live Codex catalog probe: all selected models available with 272K context and text+image input
- direct routes: `gpt-5.6-terra` and `gpt-5.5` returned `ROUTE_OK`
- auxiliary low-effort route: Luna generated `Hermes Model Routing Review`
- auxiliary medium-effort route: Luna approval-classifier call completed
- auxiliary vision route: Luna identified a generated red PNG as `red`
- `nix fmt -- nix/systems/aarch64-linux/vasyl/default.nix`
- `git diff --check`
- `nix eval` confirmed the exact model, fallback, and auxiliary settings
- `nix eval` resolved `system.build.toplevel.drvPath`
- pre-commit: deadnix, editorconfig-checker, statix, and treefmt passed; CSpell skipped because it reports 155 pre-existing project terms across the whole file
